### PR TITLE
try... catch

### DIFF
--- a/notes.txt
+++ b/notes.txt
@@ -147,3 +147,6 @@ The finally-block will always execute after the try-block and catch-block(s) hav
 
 You can nest one or more try statements. If an inner try statement does not have a catch-block, the enclosing try statement's catch-block is used instead. 
 
+
+Returning Values from Async Functions:
+

--- a/notes.txt
+++ b/notes.txt
@@ -124,3 +124,26 @@ await can be put in front of any async promise-based function to pause your code
 You can use await when calling any function that returns a Promise, including web API functions.
 
 
+Error Handling with Try Catch:
+The try...catch statement marks a block of statements to try and specifies a response should an exception be thrown. 
+
+try {
+  nonExistentFunction();
+} catch (error) {
+  console.error(error);
+  // expected output: ReferenceError: nonExistentFunction is not defined
+  // Note - error messages will vary depending on browser
+}
+
+The try statement consists of a try-block, which contains one or more statements. {} must always be used, even for single statements. A catch-block, a finally-block, or both must be present. This gives us three forms for the try statement:
+
+
+    try...catch
+    try...finally
+    try...catch...finally
+
+A catch-block contains statements that specify what to do if an exception is thrown in the try-block. If any statement within the try-block (or in a function called from within the try-block) throws an exception, control is immediately shifted to the catch-block. If no exception is thrown in the try-block, the catch-block is skipped. 
+The finally-block will always execute after the try-block and catch-block(s) have finished executing. It always executes, regardless of whether an exception was thrown or caught.
+
+You can nest one or more try statements. If an inner try statement does not have a catch-block, the enclosing try statement's catch-block is used instead. 
+

--- a/script.js
+++ b/script.js
@@ -486,6 +486,7 @@ Set the network speed to 'Fast 3G' in the dev tools Network tab, otherwise image
 GOOD LUCK 😀
 */
 
+/*
 // Solution:
 // Content node needed for Part 1:
 const imgBox = document.querySelector(`.images`);
@@ -545,22 +546,50 @@ createImage(`img/img-1.jpg`)
   })
   .catch(error => console.error(error));
 ///////////////////////////////////////////////////////////
+*/
 
 // CONSUMING PROMISES WITH ASYNC/AWAIT:
 // Using the rest countries API with async/await:
-const showCountry = async function (country) {
-  const response = await fetch(
-    `https://restcountries.com/v3.1/name/${country}`
-  );
 
-  if (!response.ok) return;
+try {
+  const showCountry = async function (country) {
+    // obtain user location:
+    const location = await userLocation();
+    console.log(location);
+    // destructure the coords object to get latitude & longitude:
+    const { latitude: lat, longitude: lng } = location.coords;
+    // ajax call to geocode api:
+    const geoResponse = await fetch(
+      `https://geocode.xyz/${lat},${lng}?geoit=json`
+    );
 
-  const data = await response.json();
+    if (!geoResponse.ok)
+      throw new Error(`😱 Location retrieval error: Check VPN!!`);
 
-  console.log(response);
-  console.log(data);
-  console.log(data[0]);
-  renderCountry(data[0]);
-};
+    console.log(geoResponse);
+    // convert data stream to json object:
+    const geoData = await geoResponse.json();
+    console.log(geoData);
+    // ajax call to rest-countries api endpoint:
+    const response = await fetch(
+      `https://restcountries.com/v3.1/name/${geoData.country}`
+    );
 
-showCountry(`Barbados`);
+    if (!response.ok)
+      throw new Error(`😱 API endpoint error: Check restcountries API!!`);
+
+    // convert data stream to json object:
+    const data = await response.json();
+
+    console.log(response);
+    console.log(data);
+    console.log(data[0]);
+    renderCountry(data[0]);
+  };
+
+  showCountry();
+} catch (error) {
+  console.error(error);
+}
+// p.s - like previous attempt, the code above throws errors when VPN is active
+//

--- a/script.js
+++ b/script.js
@@ -548,8 +548,8 @@ createImage(`img/img-1.jpg`)
 ///////////////////////////////////////////////////////////
 */
 
-// CONSUMING PROMISES WITH ASYNC/AWAIT:
-// Using the rest countries API with async/await:
+// CONSUMING PROMISES WITH ASYNC/AWAIT & try...catch:
+// Using the web APIs with async/await & try...catch:
 
 try {
   const showCountry = async function (country) {
@@ -587,9 +587,11 @@ try {
     renderCountry(data[0]);
   };
 
-  showCountry();
+  // showCountry();
 } catch (error) {
   console.error(error);
 }
-// p.s - like previous attempt, the code above throws errors when VPN is active
-//
+
+// p.s - like previous attempt, the code above throws errors when using VPN!
+
+// RETURNING VALUES FROM ASYNC FUNCTIONS:


### PR DESCRIPTION
Errors thrown within async/await blacks of code can't be caught normally using the catch method. Instead the asynchronous function is wrapped in a try block. Where errors thrown can be caught with catch.